### PR TITLE
Add skeleton Revit test runner

### DIFF
--- a/MyRevitTests/MyRevitTests.csproj
+++ b/MyRevitTests/MyRevitTests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RevitAddin\RevitAddin.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MyRevitTests/Tests.cs
+++ b/MyRevitTests/Tests.cs
@@ -1,0 +1,17 @@
+using NUnit.Framework;
+using Autodesk.Revit.DB;
+using RevitAddin;
+
+namespace MyRevitTests
+{
+    [TestFixture]
+    public class MyRevitTestsClass
+    {
+        [Test]
+        [RevitTestModel("proj-guid", "model-guid")]
+        public void TestWalls([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.DynamicallyAccessedMemberTypes.All)] Document doc)
+        {
+            Assert.IsNotNull(doc);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# RevitTestRunner
+# Revit Test Runner
+
+This repository contains a minimal proof of concept for running NUnit based Revit tests inside Revit and reporting the results back to Visual Studio Test Explorer.
+
+## Projects
+
+- **RevitAddin** – Add-in loaded into Revit. Implements a simple NUnit runner and named pipe client.
+- **RevitTestAdapter** – Custom test adapter for Visual Studio. Discovers tests and sends execution commands to Revit via named pipe.
+- **MyRevitTests** – Example test library that uses the `RevitTestModel` attribute.
+
+## Building
+
+The projects rely on NuGet packages (`NUnit`, `Microsoft.NET.Test.Sdk`, etc.). Building requires restoring those packages. In environments without internet access the restore step will fail.
+
+```bash
+dotnet build RevitTestRunner.sln
+```
+
+## Sample Test
+
+```csharp
+[Test]
+[RevitTestModel("proj-guid", "model-guid")]
+public void TestWalls(Document doc)
+{
+    Assert.IsNotNull(doc);
+}
+```

--- a/RevitAddin/PipeClient.cs
+++ b/RevitAddin/PipeClient.cs
@@ -1,0 +1,34 @@
+using System.IO.Pipes;
+using System.Text.Json;
+
+namespace RevitAddin
+{
+    public class PipeCommand
+    {
+        public string Command { get; set; } = string.Empty;
+        public string TestAssembly { get; set; } = string.Empty;
+        public string[] TestMethods { get; set; } = System.Array.Empty<string>();
+    }
+
+    public static class PipeClient
+    {
+        public static string RunTests(string pipeName, string assemblyPath, string[]? methods)
+        {
+            using var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut);
+            client.Connect();
+            var command = new PipeCommand
+            {
+                Command = "RunTests",
+                TestAssembly = assemblyPath,
+                TestMethods = methods ?? System.Array.Empty<string>()
+            };
+            var json = JsonSerializer.Serialize(command);
+            using var writer = new StreamWriter(client, leaveOpen: true);
+            writer.WriteLine(json);
+            writer.Flush();
+            using var reader = new StreamReader(client);
+            var resultPath = reader.ReadLine() ?? string.Empty;
+            return resultPath;
+        }
+    }
+}

--- a/RevitAddin/RevitAddin.csproj
+++ b/RevitAddin/RevitAddin.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit.Engine" Version="3.17.1" />
+  </ItemGroup>
+
+</Project>

--- a/RevitAddin/RevitCommand.cs
+++ b/RevitAddin/RevitCommand.cs
@@ -1,0 +1,14 @@
+using Autodesk.Revit.UI;
+using Autodesk.Revit.DB;
+
+namespace RevitAddin
+{
+    public class RevitCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            // Example invocation when launched via named pipe
+            return Result.Succeeded;
+        }
+    }
+}

--- a/RevitAddin/RevitNUnitExecutor.cs
+++ b/RevitAddin/RevitNUnitExecutor.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using Autodesk.Revit.UI;
+using NUnit.Engine;
+
+namespace RevitAddin
+{
+    public static class RevitNUnitExecutor
+    {
+        public static string ExecuteTestsInRevit(string testAssemblyPath, UIApplication uiApp)
+        {
+            using var engine = TestEngineActivator.CreateInstance();
+            var package = new TestPackage(testAssemblyPath);
+            var runner = engine.GetRunner(package);
+            var result = runner.Run(null, TestFilter.Empty);
+
+            string resultXml = result.OuterXml;
+            var resultsPath = Path.Combine(Path.GetTempPath(), "RevitTestResults.xml");
+            File.WriteAllText(resultsPath, resultXml);
+            return resultsPath;
+        }
+    }
+}

--- a/RevitAddin/RevitTestModelAttribute.cs
+++ b/RevitAddin/RevitTestModelAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace RevitAddin
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class RevitTestModelAttribute : Attribute
+    {
+        public string ProjectGuid { get; }
+        public string ModelGuid { get; }
+
+        public RevitTestModelAttribute(string projectGuid, string modelGuid)
+        {
+            ProjectGuid = projectGuid;
+            ModelGuid = modelGuid;
+        }
+    }
+}

--- a/RevitAddin/Stubs/RevitStubs.cs
+++ b/RevitAddin/Stubs/RevitStubs.cs
@@ -1,0 +1,19 @@
+namespace Autodesk.Revit.DB
+{
+    public class Document {}
+    public class TransactionGroup : System.IDisposable
+    {
+        public TransactionGroup(Document doc) {}
+        public void Start() {}
+        public void RollBack() {}
+        public void Dispose() {}
+    }
+}
+
+namespace Autodesk.Revit.UI
+{
+    public class UIApplication
+    {
+        public Autodesk.Revit.DB.Document ActiveUIDocument => new Autodesk.Revit.DB.Document();
+    }
+}

--- a/RevitTestAdapter/RevitTestAdapter.csproj
+++ b/RevitTestAdapter/RevitTestAdapter.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit.Engine" Version="3.17.1" />
+  </ItemGroup>
+
+</Project>

--- a/RevitTestAdapter/RevitTestDiscoverer.cs
+++ b/RevitTestAdapter/RevitTestDiscoverer.cs
@@ -1,0 +1,29 @@
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace RevitTestAdapter
+{
+    [FileExtension(".dll")]
+    [DefaultExecutorUri("executor://RevitTestExecutor")]
+    public class RevitTestDiscoverer : ITestDiscoverer
+    {
+        public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
+        {
+            foreach (var source in sources)
+            {
+                var assembly = System.Reflection.Assembly.LoadFrom(source);
+                foreach (var type in assembly.GetTypes())
+                {
+                    foreach (var method in type.GetMethods())
+                    {
+                        if (method.GetCustomAttributes(typeof(NUnit.Framework.TestAttribute), true).Any())
+                        {
+                            var tc = new TestCase($"{type.FullName}.{method.Name}", new Uri("executor://RevitTestExecutor"), source);
+                            discoverySink.SendTestCase(tc);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/RevitTestAdapter/RevitTestExecutor.cs
+++ b/RevitTestAdapter/RevitTestExecutor.cs
@@ -1,0 +1,72 @@
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using System.IO.Pipes;
+using System.Text.Json;
+
+namespace RevitTestAdapter
+{
+    [ExtensionUri("executor://RevitTestExecutor")]
+    public class RevitTestExecutor : ITestExecutor
+    {
+        public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
+        {
+            var assembly = tests.First().Source;
+            var testNames = tests.Select(t => t.FullyQualifiedName).ToArray();
+            var resultPath = SendRunCommand(assembly, testNames);
+            ParseResults(resultPath, frameworkHandle, assembly);
+        }
+
+        public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
+        {
+            var assembly = sources.First();
+            var resultPath = SendRunCommand(assembly, Array.Empty<string>());
+            ParseResults(resultPath, frameworkHandle, assembly);
+        }
+
+        private static string SendRunCommand(string assembly, string[] methods)
+        {
+            using var client = new NamedPipeClientStream(".", "RevitTestPipe", PipeDirection.InOut);
+            client.Connect();
+            var command = new
+            {
+                Command = "RunTests",
+                TestAssembly = assembly,
+                TestMethods = methods
+            };
+            var json = JsonSerializer.Serialize(command);
+            using var sw = new StreamWriter(client, leaveOpen: true);
+            sw.WriteLine(json);
+            sw.Flush();
+            using var sr = new StreamReader(client);
+            var result = sr.ReadLine() ?? string.Empty;
+            return result;
+        }
+
+        private static void ParseResults(string resultXmlPath, IFrameworkHandle frameworkHandle, string source)
+        {
+            var doc = System.Xml.Linq.XDocument.Load(resultXmlPath);
+            var testCases = doc.Descendants("test-case");
+            foreach (var test in testCases)
+            {
+                var fullname = test.Attribute("fullname")!.Value;
+                var outcome = test.Attribute("result")!.Value;
+                var duration = double.Parse(test.Attribute("duration")!.Value);
+                var tc = new TestCase(fullname, new Uri("executor://RevitTestExecutor"), source);
+                var tr = new TestResult(tc)
+                {
+                    Outcome = outcome == "Passed" ? TestOutcome.Passed : outcome == "Failed" ? TestOutcome.Failed : TestOutcome.Skipped,
+                    Duration = TimeSpan.FromSeconds(duration)
+                };
+                if (outcome == "Failed")
+                {
+                    var failure = test.Element("failure");
+                    tr.ErrorMessage = failure?.Element("message")?.Value;
+                    tr.ErrorStackTrace = failure?.Element("stack-trace")?.Value;
+                }
+                frameworkHandle.RecordResult(tr);
+            }
+        }
+
+        public void Cancel() { }
+    }
+}

--- a/RevitTestRunner.sln
+++ b/RevitTestRunner.sln
@@ -1,0 +1,62 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitAddin", "RevitAddin\RevitAddin.csproj", "{F55D5D43-238D-49E2-8692-1B5A71B41008}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RevitTestAdapter", "RevitTestAdapter\RevitTestAdapter.csproj", "{D7B82838-C4B1-4785-BEBD-66A34D948069}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyRevitTests", "MyRevitTests\MyRevitTests.csproj", "{800528CB-D90A-4750-846A-77ED0BF57F0D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Debug|x64.Build.0 = Debug|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Debug|x86.Build.0 = Debug|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Release|x64.ActiveCfg = Release|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Release|x64.Build.0 = Release|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Release|x86.ActiveCfg = Release|Any CPU
+		{F55D5D43-238D-49E2-8692-1B5A71B41008}.Release|x86.Build.0 = Release|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Debug|x64.Build.0 = Debug|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Debug|x86.Build.0 = Debug|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Release|x64.ActiveCfg = Release|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Release|x64.Build.0 = Release|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Release|x86.ActiveCfg = Release|Any CPU
+		{D7B82838-C4B1-4785-BEBD-66A34D948069}.Release|x86.Build.0 = Release|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Debug|x64.Build.0 = Debug|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Debug|x86.Build.0 = Debug|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Release|x64.ActiveCfg = Release|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Release|x64.Build.0 = Release|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Release|x86.ActiveCfg = Release|Any CPU
+		{800528CB-D90A-4750-846A-77ED0BF57F0D}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- add solution with Revit addin, test adapter, and sample tests
- implement `RevitTestModelAttribute` and `RevitNUnitExecutor`
- create simple VS Test Adapter skeleton
- add example NUnit test using the custom attribute
- document build instructions in README

## Testing
- `dotnet build RevitTestRunner.sln -c Release` *(fails: unable to restore packages)*
- `dotnet restore RevitTestRunner.sln` *(fails: unable to load service index)*


------
https://chatgpt.com/codex/tasks/task_e_685fba11ebec832690c12682121cb852