### PR TITLE
Ensure model open and transactions per test

### DIFF
--- a/MyRevitTests/AssemblyInfo.cs
+++ b/MyRevitTests/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: RevitAddin.RevitTransaction]

--- a/MyRevitTests/Tests.cs
+++ b/MyRevitTests/Tests.cs
@@ -9,9 +9,16 @@ namespace MyRevitTests
     {
         [Test]
         [RevitTestModel("proj-guid", "model-guid")]
-        public void TestWalls([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)] Document doc)
+        public void TestWalls()
         {
-            Assert.IsNotNull(doc);
+            Assert.IsNotNull(RevitNUnitExecutor.CurrentDocument);
+        }
+
+        [Test]
+        [RevitTestModel(@"C:\\Models\\sample.rvt")]
+        public void TestLocalFile()
+        {
+            Assert.IsNotNull(RevitNUnitExecutor.CurrentDocument);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -19,10 +19,18 @@ dotnet build RevitTestRunner.sln
 ## Sample Test
 
 ```csharp
+[assembly: RevitAddin.RevitTransaction]
 [Test]
 [RevitTestModel("proj-guid", "model-guid")]
-public void TestWalls(Document doc)
+public void TestWalls()
 {
-    Assert.IsNotNull(doc);
+    Assert.IsNotNull(RevitAddin.RevitNUnitExecutor.CurrentDocument);
 }
+```
+
+The `RevitTestModel` attribute accepts either a pair of BIM 360 GUIDs or a local
+file path:
+
+```csharp
+[RevitTestModel(@"C:\\Models\\sample.rvt")]
 ```

--- a/RevitAddin/RevitTestModelAttribute.cs
+++ b/RevitAddin/RevitTestModelAttribute.cs
@@ -1,17 +1,42 @@
 using System;
+using Autodesk.Revit.DB;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace RevitAddin
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class RevitTestModelAttribute : Attribute
+    public class RevitTestModelAttribute : Attribute, ITestAction
     {
-        public string ProjectGuid { get; }
-        public string ModelGuid { get; }
+        public string? ProjectGuid { get; }
+        public string? ModelGuid { get; }
+        public string? LocalPath { get; }
 
         public RevitTestModelAttribute(string projectGuid, string modelGuid)
         {
             ProjectGuid = projectGuid;
             ModelGuid = modelGuid;
         }
+
+        public RevitTestModelAttribute(string localPath)
+        {
+            LocalPath = localPath;
+        }
+
+        public void BeforeTest(ITest test)
+        {
+            if (LocalPath != null)
+            {
+                RevitNUnitExecutor.EnsureModelOpen(LocalPath);
+            }
+            else if (ProjectGuid != null && ModelGuid != null)
+            {
+                RevitNUnitExecutor.EnsureModelOpen(ProjectGuid, ModelGuid);
+            }
+        }
+
+        public void AfterTest(ITest test) { }
+
+        public ActionTargets Targets => ActionTargets.Test;
     }
 }

--- a/RevitAddin/RevitTransactionAttribute.cs
+++ b/RevitAddin/RevitTransactionAttribute.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace RevitAddin;
+
+/// <summary>
+/// Starts a transaction group on the active document before a test and rolls it back afterwards.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false, Inherited = true)]
+public sealed class RevitTransactionAttribute : Attribute, ITestAction
+{
+    private static readonly AsyncLocal<TransactionGroup?> _currentGroup = new();
+
+    public void BeforeTest(ITest test)
+    {
+        var uiApp = RevitNUnitExecutor.UiApplication;
+        var doc = uiApp?.ActiveUIDocument?.Document;
+        if (doc != null)
+        {
+            var tg = new TransactionGroup(doc, $"Test: {test.Name}");
+            tg.Start();
+            _currentGroup.Value = tg;
+        }
+    }
+
+    public void AfterTest(ITest test)
+    {
+        var tg = _currentGroup.Value;
+        if (tg != null)
+        {
+            tg.RollBack();
+            tg.Dispose();
+            _currentGroup.Value = null;
+        }
+    }
+
+    public ActionTargets Targets => ActionTargets.Test;
+}


### PR DESCRIPTION
## Summary
- allow opening Revit models from local file paths
- automatically wrap each test in a transaction group
- demonstrate local file usage in example tests
- document new behaviour

## Testing
- `dotnet build RevitTestRunner.sln -v minimal`
- `dotnet test RevitTestRunner.sln -v minimal --no-build` *(fails: no Revit process)*

------
https://chatgpt.com/codex/tasks/task_e_686301bbad3483269d774e851598c14b