### PR TITLE
Ensure unique XML file for test results

### DIFF
--- a/RevitAddin/RevitNUnitExecutor.cs
+++ b/RevitAddin/RevitNUnitExecutor.cs
@@ -95,7 +95,8 @@ namespace RevitAddin
             var result = runner.Run(null, filter);
 
             string resultXml = result.OuterXml;
-            var resultsPath = Path.Combine(Path.GetTempPath(), "RevitTestResults.xml");
+            var fileName = $"RevitTestResults_{Guid.NewGuid():N}.xml";
+            var resultsPath = Path.Combine(Path.GetTempPath(), fileName);
             File.WriteAllText(resultsPath, resultXml);
             return resultsPath;
         }


### PR DESCRIPTION
## Summary
- avoid static temporary filename for Revit test results
- compile after changes

## Testing
- `dotnet build RevitTestRunner.sln -v:m`

------
https://chatgpt.com/codex/tasks/task_e_68641fd1b8488326a32a63e0493212d4