### PR TITLE
Enable streaming test results

### DIFF
--- a/RevitAdapterCommon/PipeClientHelper.cs
+++ b/RevitAdapterCommon/PipeClientHelper.cs
@@ -40,4 +40,21 @@ public static class PipeClientHelper
         var result = sr.ReadLine() ?? string.Empty;
         return result;
     }
+
+    public static void SendCommandStreaming(object command, Action<string> handleLine)
+    {
+        using var client = ConnectToRevit();
+        var json = JsonSerializer.Serialize(command);
+        using var sw = new StreamWriter(client, leaveOpen: true);
+        sw.WriteLine(json);
+        sw.Flush();
+        using var sr = new StreamReader(client);
+        string? line;
+        while ((line = sr.ReadLine()) != null)
+        {
+            handleLine(line);
+            if (line == "END")
+                break;
+        }
+    }
 }

--- a/RevitAdapterCommon/PipeTestResultMessage.cs
+++ b/RevitAdapterCommon/PipeTestResultMessage.cs
@@ -1,0 +1,10 @@
+namespace RevitAdapterCommon;
+
+public class PipeTestResultMessage
+{
+    public string Name { get; set; } = string.Empty;
+    public string Outcome { get; set; } = string.Empty;
+    public double Duration { get; set; }
+    public string? ErrorMessage { get; set; }
+    public string? ErrorStackTrace { get; set; }
+}

--- a/RevitAddin/PipeTestResultMessage.cs
+++ b/RevitAddin/PipeTestResultMessage.cs
@@ -1,0 +1,10 @@
+namespace RevitAddin;
+
+public class PipeTestResultMessage
+{
+    public string Name { get; set; } = string.Empty;
+    public string Outcome { get; set; } = string.Empty;
+    public double Duration { get; set; }
+    public string? ErrorMessage { get; set; }
+    public string? ErrorStackTrace { get; set; }
+}

--- a/RevitAddin/TestCommandHandler.cs
+++ b/RevitAddin/TestCommandHandler.cs
@@ -23,18 +23,16 @@ public class TestCommandHandler : IExternalEventHandler
         if (_command == null || _pipe == null || _tcs == null)
             return;
 
-        string resultPath = _command.Command switch
-        {
-            "RunXunitTests" => RevitXunitExecutor.ExecuteTestsInRevit(_command, app),
-            "RunNUnitTests" => RevitNUnitExecutor.ExecuteTestsInRevit(_command, app),
-            _ => string.Empty
-        };
-
-        if (string.IsNullOrEmpty(resultPath))
-            return;
         using var writer = new StreamWriter(_pipe, leaveOpen: true);
-        writer.WriteLine(resultPath);
-        writer.Flush();
+        switch (_command.Command)
+        {
+            case "RunXunitTests":
+                RevitXunitExecutor.ExecuteTestsInRevit(_command, app, writer);
+                break;
+            case "RunNUnitTests":
+                RevitNUnitExecutor.ExecuteTestsInRevit(_command, app, writer);
+                break;
+        }
         _tcs.SetResult();
     }
 

--- a/RevitNUnitAdapter/RevitNUnitExecutor.cs
+++ b/RevitNUnitAdapter/RevitNUnitExecutor.cs
@@ -12,18 +12,16 @@ public class RevitNUnitExecutor : ITestExecutor
         {
             var assembly = tests.First().Source;
             var testNames = tests.Select(t => t.FullyQualifiedName).ToArray();
-            var resultPath = SendRunCommand(assembly, testNames);
-            ParseResults(resultPath, frameworkHandle, assembly);
+            SendRunCommandStreaming(assembly, testNames, frameworkHandle);
         }
 
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
             var assembly = sources.First();
-            var resultPath = SendRunCommand(assembly, Array.Empty<string>());
-            ParseResults(resultPath, frameworkHandle, assembly);
+            SendRunCommandStreaming(assembly, Array.Empty<string>(), frameworkHandle);
         }
 
-        private static string SendRunCommand(string assembly, string[] methods)
+        private static void SendRunCommandStreaming(string assembly, string[] methods, IFrameworkHandle frameworkHandle)
         {
             var command = new
             {
@@ -31,32 +29,26 @@ public class RevitNUnitExecutor : ITestExecutor
                 TestAssembly = assembly,
                 TestMethods = methods
             };
-            return PipeClientHelper.SendCommand(command);
-        }
 
-        private static void ParseResults(string resultXmlPath, IFrameworkHandle frameworkHandle, string source)
-        {
-            var doc = System.Xml.Linq.XDocument.Load(resultXmlPath);
-            var testCases = doc.Descendants("test-case");
-            foreach (var test in testCases)
+            PipeClientHelper.SendCommandStreaming(command, line =>
             {
-                var fullname = test.Attribute("fullname")!.Value;
-                var outcome = test.Attribute("result")!.Value;
-                var duration = double.Parse(test.Attribute("duration")!.Value);
-                var tc = new TestCase(fullname, new Uri("executor://RevitNUnitExecutor"), source);
+                if (line == "END")
+                    return;
+
+                var msg = JsonSerializer.Deserialize<PipeTestResultMessage>(line);
+                if (msg == null)
+                    return;
+
+                var tc = new TestCase(msg.Name, new Uri("executor://RevitNUnitExecutor"), assembly);
                 var tr = new TestResult(tc)
                 {
-                    Outcome = outcome == "Passed" ? TestOutcome.Passed : outcome == "Failed" ? TestOutcome.Failed : TestOutcome.Skipped,
-                    Duration = TimeSpan.FromSeconds(duration)
+                    Outcome = msg.Outcome == "Passed" || msg.Outcome == "Pass" ? TestOutcome.Passed : msg.Outcome == "Failed" || msg.Outcome == "Fail" ? TestOutcome.Failed : TestOutcome.Skipped,
+                    Duration = TimeSpan.FromSeconds(msg.Duration),
+                    ErrorMessage = msg.ErrorMessage,
+                    ErrorStackTrace = msg.ErrorStackTrace
                 };
-                if (outcome == "Failed")
-                {
-                    var failure = test.Element("failure");
-                    tr.ErrorMessage = failure?.Element("message")?.Value;
-                    tr.ErrorStackTrace = failure?.Element("stack-trace")?.Value;
-                }
                 frameworkHandle.RecordResult(tr);
-            }
+            });
         }
 
         public void Cancel() { }

--- a/RevitTestFramework/RevitTestFramework.csproj
+++ b/RevitTestFramework/RevitTestFramework.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
## Summary
- stream test results through the pipe instead of returning a single file
- implement streaming visitors for NUnit and xUnit
- update adapters to read incremental results
- add shared message class for pipe communication
- mark `RevitTestFramework` as not a test project to prevent missing NUnit errors

## Testing
- `dotnet build RevitTestRunner.sln -c Release`
- `dotnet test RevitTestRunner.sln -c Release` *(fails: BadImageFormatException loading RevitAPI)*

------
https://chatgpt.com/codex/tasks/task_e_686570e716e48326b71af5fc60c4d8b4