### PR TITLE
Add cancel token support across named pipe

### DIFF
--- a/RevitAdapterCommon/PipeCommand.cs
+++ b/RevitAdapterCommon/PipeCommand.cs
@@ -1,4 +1,4 @@
-namespace RevitAddin;
+namespace RevitAdapterCommon;
 
 public class PipeCommand
 {

--- a/RevitAddin/TestCommandHandler.cs
+++ b/RevitAddin/TestCommandHandler.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.IO.Pipes;
+using System.Threading;
 using System.Threading.Tasks;
 using Autodesk.Revit.UI;
 
@@ -24,13 +25,28 @@ public class TestCommandHandler : IExternalEventHandler
             return;
 
         using var writer = new StreamWriter(_pipe, leaveOpen: true);
+
+        using var cancelClient = new NamedPipeClientStream(".", _command.CancelPipe, PipeDirection.In);
+        var cts = new CancellationTokenSource();
+        try
+        {
+            cancelClient.Connect(100);
+            _ = Task.Run(() =>
+            {
+                using var sr = new StreamReader(cancelClient);
+                sr.ReadLine();
+                cts.Cancel();
+            });
+        }
+        catch { }
+
         switch (_command.Command)
         {
             case "RunXunitTests":
-                RevitXunitExecutor.ExecuteTestsInRevit(_command, app, writer);
+                RevitXunitExecutor.ExecuteTestsInRevit(_command, app, writer, cts.Token);
                 break;
             case "RunNUnitTests":
-                RevitNUnitExecutor.ExecuteTestsInRevit(_command, app, writer);
+                RevitNUnitExecutor.ExecuteTestsInRevit(_command, app, writer, cts.Token);
                 break;
         }
         _tcs.SetResult();

--- a/RevitNUnitAdapter/RevitNUnitExecutor.cs
+++ b/RevitNUnitAdapter/RevitNUnitExecutor.cs
@@ -2,32 +2,38 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using RevitAdapterCommon;
 using System.Text.Json;
+using System.Threading;
+using System;
 
 namespace RevitNUnitAdapter
 {
     [ExtensionUri("executor://RevitNUnitExecutor")]
 public class RevitNUnitExecutor : ITestExecutor
 {
+        private CancellationTokenSource? _cts;
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
+            _cts = new CancellationTokenSource();
             var assembly = tests.First().Source;
             var testNames = tests.Select(t => t.FullyQualifiedName).ToArray();
-            SendRunCommandStreaming(assembly, testNames, frameworkHandle);
+            SendRunCommandStreaming(assembly, testNames, frameworkHandle, _cts.Token);
         }
 
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
+            _cts = new CancellationTokenSource();
             var assembly = sources.First();
-            SendRunCommandStreaming(assembly, Array.Empty<string>(), frameworkHandle);
+            SendRunCommandStreaming(assembly, Array.Empty<string>(), frameworkHandle, _cts.Token);
         }
 
-        private static void SendRunCommandStreaming(string assembly, string[] methods, IFrameworkHandle frameworkHandle)
+        private static void SendRunCommandStreaming(string assembly, string[] methods, IFrameworkHandle frameworkHandle, CancellationToken token)
         {
-            var command = new
+            var command = new PipeCommand
             {
                 Command = "RunNUnitTests",
                 TestAssembly = assembly,
-                TestMethods = methods
+                TestMethods = methods,
+                CancelPipe = "RevitCancel_" + Guid.NewGuid().ToString("N")
             };
 
             PipeClientHelper.SendCommandStreaming(command, line =>
@@ -48,9 +54,9 @@ public class RevitNUnitExecutor : ITestExecutor
                     ErrorStackTrace = msg.ErrorStackTrace
                 };
                 frameworkHandle.RecordResult(tr);
-            });
+            }, token);
         }
 
-        public void Cancel() { }
+        public void Cancel() { _cts?.Cancel(); }
     }
 }

--- a/RevitTestFramework/RevitModelService.cs
+++ b/RevitTestFramework/RevitModelService.cs
@@ -1,5 +1,6 @@
 using System;
 using Autodesk.Revit.DB;
+using System.Threading;
 
 namespace RevitTestFramework;
 
@@ -8,4 +9,5 @@ public static class RevitModelService
     public static Func<string, Document>? OpenLocalModel { get; set; }
     public static Func<string, string, Document>? OpenCloudModel { get; set; }
     public static Document? CurrentDocument { get; set; }
+    public static CancellationToken CancellationToken { get; set; } = CancellationToken.None;
 }

--- a/RevitXunitAdapter/RevitXunitExecutor.cs
+++ b/RevitXunitAdapter/RevitXunitExecutor.cs
@@ -2,32 +2,38 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using RevitAdapterCommon;
 using System.Text.Json;
+using System.Threading;
+using System;
 
 namespace RevitXunitAdapter
 {
     [ExtensionUri("executor://RevitXunitExecutor")]
 public class RevitXunitExecutor : ITestExecutor
     {
+        private CancellationTokenSource? _cts;
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
+            _cts = new CancellationTokenSource();
             var assembly = tests.First().Source;
             var testNames = tests.Select(t => t.FullyQualifiedName).ToArray();
-            SendRunCommandStreaming(assembly, testNames, frameworkHandle);
+            SendRunCommandStreaming(assembly, testNames, frameworkHandle, _cts.Token);
         }
 
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
+            _cts = new CancellationTokenSource();
             var assembly = sources.First();
-            SendRunCommandStreaming(assembly, Array.Empty<string>(), frameworkHandle);
+            SendRunCommandStreaming(assembly, Array.Empty<string>(), frameworkHandle, _cts.Token);
         }
 
-        private static void SendRunCommandStreaming(string assembly, string[] methods, IFrameworkHandle frameworkHandle)
+        private static void SendRunCommandStreaming(string assembly, string[] methods, IFrameworkHandle frameworkHandle, CancellationToken token)
         {
-            var command = new
+            var command = new PipeCommand
             {
                 Command = "RunXunitTests",
                 TestAssembly = assembly,
-                TestMethods = methods
+                TestMethods = methods,
+                CancelPipe = "RevitCancel_" + Guid.NewGuid().ToString("N")
             };
 
             PipeClientHelper.SendCommandStreaming(command, line =>
@@ -48,9 +54,9 @@ public class RevitXunitExecutor : ITestExecutor
                     ErrorStackTrace = msg.ErrorStackTrace
                 };
                 frameworkHandle.RecordResult(tr);
-            });
+            }, token);
         }
 
-        public void Cancel() { }
+        public void Cancel() { _cts?.Cancel(); }
     }
 }


### PR DESCRIPTION
## Summary
- support cancellation of test execution via named pipe
- expose `CancellationToken` through `RevitModelService`
- listen for cancel messages in add-in command handler
- propagate cancellation to NUnit and xUnit executors and adapters

## Testing
- `dotnet build RevitTestRunner.sln -v q`

------
https://chatgpt.com/codex/tasks/task_e_68659acd12648326afbcf47277e18128